### PR TITLE
幅を狭くした場合のスタイルを調整

### DIFF
--- a/app/src/components/FiletreeView.vue
+++ b/app/src/components/FiletreeView.vue
@@ -18,6 +18,15 @@
     }
   }
 
+  // .viewport width + .file-tree width
+  @media screen and (max-width: 856px) {
+    .file-tree.active {
+      &.active {
+        display: none;
+      }
+    }
+  }
+
   .tree-search {
     padding: 3px 2px;
     border-bottom: 1px solid #cccccc;

--- a/app/src/components/FiletreeView.vue
+++ b/app/src/components/FiletreeView.vue
@@ -18,15 +18,6 @@
     }
   }
 
-  // .viewport width + .file-tree width
-  @media screen and (max-width: 856px) {
-    .file-tree.active {
-      &.active {
-        display: none;
-      }
-    }
-  }
-
   .tree-search {
     padding: 3px 2px;
     border-bottom: 1px solid #cccccc;

--- a/app/src/components/FooterView/FilepathView.vue
+++ b/app/src/components/FooterView/FilepathView.vue
@@ -10,6 +10,8 @@
     box-shadow: inset 1px 1px rgba(0,0,0,.1);
     flex-grow: 1;
     margin: 0 5px;
+    white-space: nowrap;
+    overflow: auto;
   }
   .filepath-text {
     -webkit-user-select: initial;

--- a/app/src/components/ToolbarView.vue
+++ b/app/src/components/ToolbarView.vue
@@ -22,7 +22,7 @@
     position: relative;
   }
   .btn-group {
-    display: flex; /* Overwrite for photon.css */
+    display: flex; // Overwrite for photon.css
     margin: 0 5px 0 6px;
   }
   .btn {

--- a/app/src/components/ToolbarView.vue
+++ b/app/src/components/ToolbarView.vue
@@ -19,10 +19,10 @@
     border-top: 1px solid #989898;
     border-bottom: 1px solid #989898;
     /*flex-wrap: wrap;*/
-    min-width: 900px;
     position: relative;
   }
   .btn-group {
+    display: flex; /* Overwrite for photon.css */
     margin: 0 5px 0 6px;
   }
   .btn {
@@ -350,4 +350,3 @@
     }
   }
 </script>
-


### PR DESCRIPTION
@nakajmg 
エディタと左右に並べて使いたくて、幅を狭くしたとき用のスタイルを追加しました。

- ツールバーの表示崩れの修正
- サイドバーの非表示

<img width="839" alt="before" src="https://cloud.githubusercontent.com/assets/469904/21840597/a27a6384-d821-11e6-92ff-2cf26cb8eda0.png">

↓

<img width="841" alt="after" src="https://cloud.githubusercontent.com/assets/469904/21840596/a27a22c0-d821-11e6-9f39-3417a3665ccc.png">
