### PR TITLE
fix: ビルドが通らない問題を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ Toggle Textlint Reporter| Cmd+Shift+T
 Toggle Viewport Resizer| Cmd+Shift+I
 Toggle Developer Tools|Cmd+Alt+I
 
+
+## Development
+
+Install and run `dev` npm-run-scripts.
+
+```
+npm install
+# postinstall: cd app && npm install
+npm run dev
+# start electron app
+```
+
 ---
 
 This project was generated from [electron-vue](https://github.com/SimulatedGREG/electron-vue) using [vue-cli](https://github.com/vuejs/vue-cli). Documentation about this project can be found [here](https://simulatedgreg.gitbooks.io/electron-vue/content/index.html).

--- a/app/package.json
+++ b/app/package.json
@@ -13,9 +13,9 @@
     "request": "^2.75.0",
     "textlint": "^7.1.1",
     "textlint-rule-prh": "^3.1.1",
-    "vue": "next",
+    "vue": "^2.0.0",
     "vue-electron": "^1.0.0",
-    "vuex": "next"
+    "vuex": "^2.0.0"
   },
   "devDependencies": {},
   "author": "nakajmg <nakajima.jmg@gmail.com>"

--- a/app/src/components/PreviewView.vue
+++ b/app/src/components/PreviewView.vue
@@ -136,8 +136,8 @@
     transition: all 100ms ease-out;
   }
   .webview {
+    display:inline-flex;
     flex-grow: 1;
-    height: 100%;
     /*box-shadow: rgba(193, 193, 193, .5) 2px 2px 0px;*/
     /*margin-top: 40px;*/
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint --ext .js,.vue -f ./node_modules/eslint-friendly-formatter app",
     "lint:fix": "eslint --ext .js,.vue -f ./node_modules/eslint-friendly-formatter --fix app",
     "pack": "cross-env NODE_ENV=production webpack -p --progress --colors",
-    "postinstall": "npm run lint:fix && cd app && npm install",
+    "postinstall": "cd app && npm install",
     "vuex:module": "node tasks/vuex/module.js",
     "build-manual": "rm -rf builds/cgmd-preview && npm run pack && electron-packager ./app cgmd-browser --out=builds --platform=darwin --arch=x64 --overwrite=true"
   },
@@ -54,7 +54,8 @@
     "url-loader": "^0.5.7",
     "vue-hot-reload-api": "^1.3.2",
     "vue-html-loader": "^1.2.2",
-    "vue-loader": "next",
+    "vue-loader": "^10.0.0",
+    "vue-template-compiler": "^2.1.10",
     "vue-style-loader": "^1.0.0",
     "webpack": "^1.13.0",
     "webpack-dev-server": "^1.14.1"

--- a/tasks/runner.js
+++ b/tasks/runner.js
@@ -38,7 +38,7 @@ function run (command, color, name) {
      *
      * NOTE: needs more testing for stability
      */
-    if (/VALID/g.test(data.toString().trim().replace(/\n/g, '\n' + repeat(' ', command.length + 2))) && !isElectronOpen) {
+    if (/Compiled successfully/g.test(data.toString().trim().replace(/\n/g, '\n' + repeat(' ', command.length + 2))) && !isElectronOpen) {
       console.log(`${BLUE}Starting electron...\n${END}`)
       run('cross-env NODE_ENV=development electron app/electron.js', BLUE, 'electron')
       isElectronOpen = true


### PR DESCRIPTION
@nakajmg ビルドできなかったので次の修正をしました

- 必ず失敗していたlintをpostinstallから外した
- vueのバージョンを指定(nextはもう存在しないため)
- webpackのビルドメッセージ検知の変更
- peerDependencyであるvue-template-compilerを追加
- webviewにdisplay:inline-flexを指定
  - webviewの中身が見えなかったので
  - https://github.com/electron/electron/blob/master/docs-translations/jp/api/webview-tag.md#css-styling-notes