### PR TITLE
fix: アイコンがスクロールしてクリックできなくなる問題を修正

### DIFF
--- a/app/src/components/FiletreeView.vue
+++ b/app/src/components/FiletreeView.vue
@@ -85,7 +85,6 @@
     .tree-file-text {
       white-space: nowrap;
       width: 170px;
-      overflow: scroll;
     }
   }
   .tree-epmty {


### PR DESCRIPTION
ファイルツリーのアイコンをクリックすると、
なぜか次からはクリックできなくなる現象が起きてました
(スタイルをつけたり外すと直ったりする)

![2 -08-2017 19-58-12](https://cloud.githubusercontent.com/assets/19714/22734457/1b57a046-ee39-11e6-8110-e95d5b8fc38a.gif)

この灰色っぽいのが`overflow: scroll;`ででていたスクロールバーの領域となっていて、
スクロールバーがでるとアイコンがクリックできなくなるようでした。

なので `overflow: scroll;` を取り除くことで改善できると思います。

@nakajmg 