### PR TITLE
fix: 相対パスの画像読み込みに対応

### DIFF
--- a/app/electron.js
+++ b/app/electron.js
@@ -9,6 +9,7 @@ const wordCounter = require('./src/wordCounter')
 const watcher = {}
 const chokidar = require('chokidar')
 const axios = require('axios')
+const isURL = require('is-url')
 let mainWindow
 let config = {}
 const linter = require('./linter')
@@ -244,6 +245,10 @@ function createWindow () {
       const count = wordCounter(file)
       // ローカルの画像を読み込んでbase64で埋め込む
       const replacedFile = file.replace(/!\[([^\]]*?)\]\(([^)"'\s]+).*\)/g, (rep, $1, $2) => {
+        // URLであるなら処理をしない
+        if(isURL($2)){
+          return rep;
+        }
         let local = path.resolve(path.dirname(filepath), $2)
         try {
           let img = fs.readFileSync(local)
@@ -251,7 +256,7 @@ function createWindow () {
         }
         catch(err) {
           // ファイルが読み込めなかったらそのまま返す
-          return `![${$1}](./${$2})`
+          return `![${$1}](${$2})`
         }
       })
       // iframe の src を収集

--- a/app/electron.js
+++ b/app/electron.js
@@ -242,11 +242,9 @@ function createWindow () {
       }
 //      const extension = path.extname(filepath)
       const count = wordCounter(file)
-
-      const dirname = path.dirname(filepath)
       // ローカルの画像を読み込んでbase64で埋め込む
-      const replacedFile = file.replace(/!\[(.*?)\]\(\.\/(.*)\)/g, (rep, $1, $2) => {
-        let local = `${dirname}/${$2}`;
+      const replacedFile = file.replace(/!\[([^\]]*?)\]\(([^)"'\s]+).*\)/g, (rep, $1, $2) => {
+        let local = path.resolve(path.dirname(filepath), $2)
         try {
           let img = fs.readFileSync(local)
           return `![${$1}](data:image/png;base64,${new Buffer(img).toString('base64')})`
@@ -256,7 +254,6 @@ function createWindow () {
           return `![${$1}](./${$2})`
         }
       })
-
       // iframe の src を収集
       const urls = []
       replacedFile.replace(/<iframe.*(data-)?src="(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*))".*<\/iframe>/g, (rep, $1, $2) => {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "codegrid-markdown": "^3.3.0",
     "directory-tree": "^1.1.1",
     "electron-search-text": "^0.3.0",
+    "is-url": "^1.2.2",
     "lodash": "^4.16.1",
     "open": "0.0.5",
     "request": "^2.75.0"


### PR DESCRIPTION
現状だとそのMarkdownファイル以下のファイルしか参照できませんが、[path.resolve](https://nodejs.org/api/path.html#path_path_resolve_paths "path.resolve")を使い、
`path.resolve(Markdownのパス, 画像のパス)` で画像の絶対パスが手に入るようにしました。

```
![fig](../display/img/fig-1.png)
![fig](../img/fig-1.png)
![fig](img/fig-1.png "alt")
```

などの画像が表示できるようになるはずです

![cgmd-browser 2017-02-08 20-14-47](https://cloud.githubusercontent.com/assets/19714/22735137/cec99790-ee3b-11e6-9797-7c98d078bdde.png)
